### PR TITLE
Add valueDidChange method.

### DIFF
--- a/addon/components/simditor-editor.js
+++ b/addon/components/simditor-editor.js
@@ -15,6 +15,13 @@ export default Ember.Component.extend({
     defaultImage: 'assets/passed.png',
     placeholder: 'Type something here',
     locale: 'en-US',
+    valueDidChange: Ember.observer('value', function() {
+      let thisEditor = this.get('editor');
+      let editorValue = thisEditor.getValue();
+      if(this.value !== editorValue) {
+        thisEditor.setValue(this.value);
+      }
+    }),
     didInsertElement(){
         let self = this;
         Simditor.locale = this.get('locale');


### PR DESCRIPTION
`valueDidChange` updates Simditor's value if it does not match `this.value`.  This can occur if the editor's value is based on `model.text` for example, and `model.text` changes (as when going to a different sub-route, eg from `items/3` to `items/5`).